### PR TITLE
Resolve Device Not Available for CPU

### DIFF
--- a/yolo_onnx/yolov8_onnx.py
+++ b/yolo_onnx/yolov8_onnx.py
@@ -4,7 +4,7 @@ import numpy as np
 
 class YOLOv8:
 
-    def __init__(self, model_path, device="CPU", half=False):
+    def __init__(self, model_path, device="cpu", half=False):
         if device == 'cpu':
             providers = ['CPUExecutionProvider']
         elif device == 'gpu':


### PR DESCRIPTION
**Summary**
This pull request fixes an issue in the YOLOv8 model initialization where the device parameter comparison caused an assertion error. The device parameter was previously set to "CPU" by default, which did not match the condition 'cpu', leading to a failure when initializing the model on a CPU. This parameter seems to accidently have been changed on [1475458](https://github.com/trainyolo/YOLO-ONNX/commit/147545876b9b783af47bc324764ebdf113a91686). This has also been raised by another user in the following [issue](https://github.com/trainyolo/YOLO-ONNX/issues/2).

**Problem**
The model initialization code in yolov8_onnx.py was checking the device parameter against lowercase 'cpu' and 'gpu', but the default value for device was set to "CPU". This mismatch resulted in an assertion error as shown below:

```
[ERROR] AssertionError: Device CPU is not available.
Traceback (most recent call last):
  File "/var/lang/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/var/task/app.py", line 8, in <module>
    yolov8_detector = YOLOv8('./models/yolov8-sku-detector.onnx')
  File "/var/task/yolo_onnx/yolov8_onnx.py", line 13, in __init__
    assert False, f'Device {device} is not available.'
```

**Solution**
The solution involves changing the default value of the device parameter from "CPU" to "cpu". This ensures that the comparison with 'cpu' succeeds, allowing the model to initialize correctly on a CPU. Here are the changes made:

```
def __init__(self, model_path, device="cpu", half=False):
    if device == 'cpu':
        providers = ['CPUExecutionProvider']
    elif device == 'gpu':
        providers = ['CUDAExecutionProvider']
    else:
        assert False, f'Device {device} is not available.'

    self.session = onnxruntime.InferenceSession(model_path, providers=providers)
    self.half = half
```

**Impact**
Ensures that the model initializes correctly on a CPU without causing an assertion error.
Improves the robustness of the device parameter handling in the YOLOv8 model initialization.

**Testing**
Verified that the model initializes correctly on both CPU and GPU by setting the device parameter to 'cpu' and 'gpu' respectively.
Ensured that no assertion error occurs when the device parameter is set to its default value.





